### PR TITLE
Plugins updated + Heroku config

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn slask:app

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@
 
 ![kitten mittens](http://i.imgur.com/xhmD6QO.png)
 
+## Heroku
+
+You can host for free on [Heroku](http://heroku.com). Sign up and follow the steps below to deploy the app.
+
+```bash
+heroku create
+git push heroku master
+heroku ps:scale web=1
+heroku ps
+heroku logs
+```
+
 ## Commands
 
 Right now, `!gif`, `!image`, `!youtube` and `!wiki` are the only available commands.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ beautifulsoup4==4.3.2
 itsdangerous==0.23
 requests==2.2.1
 wsgiref==0.1.2
+gunicorn==18.0


### PR DESCRIPTION
Moved out from the msg.get in plugins so they would be compatible with the
daemon version I'm porting it to use with Amazon SQS integration.
Added info to use Heroku to host app for free.

My daemon version is here: https://github.com/fsalum/slackbot-python
