### PR TITLE
Loop hook

### DIFF
--- a/slask.py
+++ b/slask.py
@@ -113,7 +113,7 @@ def main(config):
                 if response:
                     client.rtm_send_message(event["channel"], response)
             
-            run_hook(hooks, "loop", None, config)
+            run_hook(hooks, "loop", None, {"client": client, "config": config, "hooks": hooks})
             
             correction = 1 - (time.time() - start)
             if correction > 0:

--- a/slask.py
+++ b/slask.py
@@ -110,6 +110,9 @@ def main(config):
                 response = handle_event(client, event, hooks, config)
                 if response:
                     client.rtm_send_message(event["channel"], response)
+            
+            run_hook(hooks, "loop", None, config)
+            
             time.sleep(1)
     else:
         logging.warn("Connection Failed, invalid token <{0}>?".format(config["token"]))

--- a/slask.py
+++ b/slask.py
@@ -104,6 +104,8 @@ def main(config):
     if client.rtm_connect():
         users = client.server.users
         while True:
+            start = time.time()
+            
             events = client.rtm_read()
             for event in events:
                 logging.debug("got {0}".format(event.get("type", event)))
@@ -113,7 +115,9 @@ def main(config):
             
             run_hook(hooks, "loop", None, config)
             
-            time.sleep(1)
+            correction = 1 - (time.time() - start)
+            if correction > 0:
+                time.sleep(correction)
     else:
         logging.warn("Connection Failed, invalid token <{0}>?".format(config["token"]))
 


### PR DESCRIPTION
I added a hook so that plugins can implement an `on_loop` function where they can do processing if needed since otherwise they get no processor-time unless their specific message is called.

I also added a loop time correction so that heavy plugins (whether in on_loop or on_message) don't slow down the responsiveness of the bot as much.