### PR TITLE
don't ping quite as much

### DIFF
--- a/limbo/limbo.py
+++ b/limbo/limbo.py
@@ -154,19 +154,30 @@ def init_config():
 
 def loop(server):
     try:
+        loops_without_activity = 0
         while True:
             start = time.time()
 
-            # This will cause a broken pipe to reveal itself
-            server.slack.server.ping()
+            # The Slack RTM API docs say:
+            #
+            # > When there is no other activity clients should send a ping
+            # > every few seconds
+            #
+            # So, if we've gone 5 seconds without any activity, send a ping. If
+            # the connection has broken, this will reveal it so slack can quit
+            if loops_without_activity > 5:
+                server.slack.server.ping()
+                loops_without_activity = -1
 
             events = server.slack.rtm_read()
             for event in events:
+                loops_without_activity = -1
                 logger.debug("got {0}".format(event.get("type", event)))
                 response = handle_event(event, server)
                 if response:
                     server.slack.rtm_send_message(event["channel"], response)
 
+            loops_without_activity += 1
             end = time.time()
             runtime = start - end
             time.sleep(max(1-runtime, 0))


### PR DESCRIPTION
The Slack RTM API docs say:

> When there is no other activity clients should send a ping
> every few seconds

So, if we've gone 5 seconds without any activity, send a ping. If
the connection has broken, this will reveal it so slack can quit

Also: the 5 second delay is actually more like an 8 second delay, because receiving the `pong` on the next loop resets the counter to zero, so with no activity the loops go:

>  0, 1, 2, 3, 4, 5, 6, `ping`, `pong`, 0, 1, 2, 3, 4, 5, 6 `ping`, ...