### PR TITLE
Adding Docker support using python 3.4

### DIFF
--- a/.docker/supervisord.conf
+++ b/.docker/supervisord.conf
@@ -5,5 +5,5 @@ loglevel=info
 logfile=/dev/stdout
 logfile_maxbytes=0
 
-[program:raven]
+[program:limbo]
 command=python3 /deploy/app/bin/limbo

--- a/.docker/supervisord.conf
+++ b/.docker/supervisord.conf
@@ -1,0 +1,9 @@
+[supervisord]
+nodaemon=true
+loglevel=info
+# log to stdout for docker
+logfile=/dev/stdout
+logfile_maxbytes=0
+
+[program:raven]
+command=python3 /deploy/app/bin/raven

--- a/.docker/supervisord.conf
+++ b/.docker/supervisord.conf
@@ -7,3 +7,12 @@ logfile_maxbytes=0
 
 [program:limbo]
 command=python3 /deploy/app/bin/limbo
+autostart=true
+autorestart=true
+user=root
+# log to stdout for docker
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+# disable logfile rotation
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0

--- a/.docker/supervisord.conf
+++ b/.docker/supervisord.conf
@@ -6,4 +6,4 @@ logfile=/dev/stdout
 logfile_maxbytes=0
 
 [program:raven]
-command=python3 /deploy/app/bin/raven
+command=python3 /deploy/app/bin/limbo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM skiftcreative/supervisor:3.4
+FROM skiftcreative/supervisor:3.3
 MAINTAINER Shawn McElroy <shawn@skift.io>
 
 ENV SLACK_TOKEN "xoxb..."
@@ -21,7 +21,6 @@ COPY . /deploy/app
 
 RUN pip3 install -U pip setuptools
 
-RUN pip3 install -U certifi
 RUN pip3 install -r /deploy/app/requirements.txt
 RUN cd /deploy/app \
     && python3 /deploy/app/setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM skiftcreative/supervisor:3.4
+MAINTAINER Shawn McElroy <shawn@skift.io>
+
+ENV SLACK_TOKEN "xoxb..."
+
+COPY . /deploy/app
+
+RUN pip3 install -U pip
+
+RUN pip3 install -r /deploy/app/requirements.txt \
+    && python setup.py install
+
+COPY docker/supervisord.conf /etc/supervisord.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,10 @@ ENV SLACK_TOKEN "xoxb..."
 
 COPY . /deploy/app
 
-RUN pip3 install -U pip
+RUN pip3 install -U pip setuptools
 
 RUN pip3 install -r /deploy/app/requirements.txt \
-    && python setup.py install
+    && cd /deploy/app \
+    && python3 /deploy/app/setup.py install
 
-COPY docker/supervisord.conf /etc/supervisord.conf
+COPY .docker/supervisord.conf /etc/supervisord.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,29 @@ MAINTAINER Shawn McElroy <shawn@skift.io>
 
 ENV SLACK_TOKEN "xoxb..."
 
+RUN apk add --no-cache --virtual .build-deps  \
+    bzip2-dev \
+    gcc \
+    libc-dev \
+    linux-headers \
+    make \
+    ncurses-dev \
+    openssl-dev \
+    pax-utils \
+    readline-dev \
+    sqlite-dev \
+    zlib-dev \
+    libffi-dev
+
 COPY . /deploy/app
 
 RUN pip3 install -U pip setuptools
 
-RUN pip3 install -r /deploy/app/requirements.txt \
-    && cd /deploy/app \
+RUN pip3 install -U certifi
+RUN pip3 install -r /deploy/app/requirements.txt
+RUN cd /deploy/app \
     && python3 /deploy/app/setup.py install
+
+RUN apk del .build-deps
 
 COPY .docker/supervisord.conf /etc/supervisord.conf

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ docker_build:
 
 .PHONY: docker_run
 docker_run:
-	docker run --name=${APP} --detach=true -p 5000:5000 ${NAMESPACE}/${APP}
+	docker run --name=${APP} --detach=true -e SLACK_TOKEN=${SLACK_TOKEN} ${NAMESPACE}/${APP}
 
 .PHONY: docker_clean
 docker_clean:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+NAMESPACE=llimllib
+APP=limbo
+
 .PHONY: testall
 testall: requirements
 	tox
@@ -42,3 +45,23 @@ publish:
 .PHONY: flake8
 flake8:
 	flake8 limbo test
+
+.PHONY: docker_build
+docker_build:
+	docker build -t ${NAMESPACE}/${APP} .
+
+.PHONY: docker_run
+docker_run:
+	docker run --name=${APP} --detach=true -p 5000:5000 ${NAMESPACE}/${APP}
+
+.PHONY: docker_clean
+docker_clean:
+	docker stop ${APP} && docker rm ${APP}
+
+.PHONY: docker_reset
+docker_reset: docker_clean
+	docker rmi ${NAMESPACE}/${APP}
+
+.PHONY: docker_push
+docker_push:
+	docker push ${NAMESPACE}/${APP}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ html5lib==0.9999999
 PyYAML==3.11
 backports.ssl-match-hostname==3.4.0.2
 beautifulsoup4==4.4.1
+certifi==2015.11.20.1
 contextlib2==0.4.0
 flake8==2.3.0
 mccabe==0.3
@@ -9,7 +10,7 @@ mock==1.0.1
 nose==1.3.4
 pep8==1.6.2
 pyflakes==0.8.1
-requests==2.5.2
+requests[security]==2.9.1
 six==1.9.0
 vcrpy==1.2.0
 websocket-client==0.32.0

--- a/stackfile.yml
+++ b/stackfile.yml
@@ -1,0 +1,4 @@
+limbo:
+  image: skiftcreative/supervisor:3.4
+  envorinment:
+    - SLACK_TOKEN="xoxb..."


### PR DESCRIPTION
With this change, it makes it easy to push this project into a running docker server. By default I am using python3.4 as it is the latest supported version of python. And if we do docker tagging, it should likely be based on the current released version of `limbo`.

This is based from a supervisord image I created and regularly use in my deployment scenarios using python. From there the current `Dockerfile` pushes a `supervisord.conf` file onto the image that controls supervisor and what it runs. Currently it just runs the `limbo` binary directly. Which for our purposes should work perfectly fine if the docker images are tagged to match the versions of limbo.

I also added a `stackfile.yml` which can be user on tutum.co, which is now being released as [Docker Cloud](http://cloud.docker.com/) as tutum was purchased by Docker Inc. Because it is simple it should also work as a custom config file for `docker-compose` as well. All you need to do is set the `SLACK_TOKEN` env variable for it to work.

I have also updated the `Makefile` to show the new commands and how a user would run them on their machine.

If ultimately you would want to use this to publish an official limbo docker image I can help with that. The changes would be minor.