### PR TITLE
change hooking regexp to not attempt to hook on all `on_` functions

### DIFF
--- a/limbo/limbo.py
+++ b/limbo/limbo.py
@@ -76,7 +76,7 @@ def init_plugins(plugindir, plugins_to_load=None):
         try:
             mod = importlib.import_module(plugin)
             modname = mod.__name__
-            for hook in re.findall("on_(\w+)", " ".join(dir(mod))):
+            for hook in re.findall("\ on_(\w+)", " ".join(dir(mod))):
                 hookfun = getattr(mod, "on_" + hook)
                 logger.debug("plugin: attaching %s hook for %s", hook, modname)
                 hooks.setdefault(hook, []).append(hookfun)


### PR DESCRIPTION
this merge prevents limbo from attempting to greedily match all functions containing on_, like function_map() or action_items().