### PR TITLE
Alternative Docker/Kubernetes support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM gliderlabs/alpine:3.3
+
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# get our basic-needs sorted
+RUN apk-install python3 python3-dev vim bash    \
+                curl      \
+    && curl "https://bootstrap.pypa.io/get-pip.py" | python3 \
+    && pip install --upgrade pip setuptools     \
+    && ln -s /usr/bin/python3 /usr/bin/python   \
+    && mkdir -p /opt /app
+
+ADD . /app
+WORKDIR /app
+RUN pip install -e .
+CMD /app/bin/kube-limbo
+
+# vim: set expandtab tabstop=4 shiftwidth=4 autoindent smartindent:

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,4 @@
+FROM petergrace/limbo
+# Add your plugins with lines similar to these
+ADD limbo/plugins/my_new_plugin.py /app/limbo/plugins/
+ADD limbo/plugins/my_other_new_plugin.py /app/limbo/plugins/

--- a/README.md
+++ b/README.md
@@ -54,8 +54,12 @@ These are the current default plugins:
 
 ---
 ## FAQ
+  * How do I try out Limbo via docker?
+    - @PeterGrace maintains a public build of limbo, available from the docker registry.  Executing `docker run -d -e SLACK_TOKEN=<your_token> petergrace/limbo` will start the default bot.
   * When I start the docker container, I see an error about unable to source limbo.env.  Is this a problem?
     - No.  The limbo.env file only exists when using Kubernetes with the included opaque secret recipe for storing your environment variables.
+  * I'd like to develop plugins for Limbo, but would still like to use Docker to run the bot.  Is there a quick way to add plugins to the bot?
+    - Yes!  Use the included Dockerfile.dev as a template, and simply build via `docker build -f Dockerfile.dev -t <new_image_name> .`  You'll then need to start the bot with your new_image_name, for example `docker run -d -e SLACK_TOKEN=<your_token> new_image_name`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ These are the current default plugins:
 * [youtube](https://github.com/llimllib/limbo/wiki/Youtube-Plugin)
 
 ---
+## FAQ
+  * When I start the docker container, I see an error about unable to source limbo.env.  Is this a problem?
+    - No.  The limbo.env file only exists when using Kubernetes with the included opaque secret recipe for storing your environment variables.
+
+---
 
 ## Contributors
 

--- a/bin/kube-limbo
+++ b/bin/kube-limbo
@@ -1,0 +1,3 @@
+#!/bin/bash
+source /tmp/secrets/limbo.env
+/app/bin/limbo

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,13 @@
+Kubernetes and Secrets
+======================
+Kubernetes has in-built support for handling secrets in a cluster.
+
+How do I update secrets?
+========================
+  1. (optional) if you are committing this to a git repo, you may want to use blackbox (https://github.com/stackexchange/blackbox) to encrypt those secrets.  Initialize your blackbox inside repo.
+  2. edit limbo.env (`blackbox_edit limbo.env` in the case of blackbox)
+  3. commit the change, if needed.
+  4. execute `recreate_secrets.sh` which should delete and recreate an opaque secret in Kubernetes, named `limbo-secret-env-vars`
+  5. delete the currently running Limbo pod to propogate the new secret (restarting a pod won't fetch a new secret)
+
+

--- a/kubernetes/limbo-rc.yaml
+++ b/kubernetes/limbo-rc.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    app: limbo
+    environment: production   
+  name: limbo-rc
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    app: limbo
+    environment: production   
+  template:
+    metadata:
+      labels:
+        app: limbo
+        environment: production    
+    spec:
+      volumes:
+      - name: "env-secrets"
+        secret:
+          secretName: "limbo-secret-env-vars"
+      containers:
+        - image: petergrace/limbo:latest
+        imagePullPolicy: Always
+        name: limbo
+        resources: {}
+        volumeMounts:
+          - name: "env-secrets"
+            mountPath: "/tmp/secrets"
+            readOnly: true  
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30

--- a/kubernetes/limbo.env
+++ b/kubernetes/limbo.env
@@ -1,0 +1,3 @@
+export SLACK_TOKEN="your-slack-token"
+export LIMBO_LOGLEVEL="DEBUG"
+export WEATHER_API_KEY="your-openweather-key"

--- a/kubernetes/recreate_secret.sh
+++ b/kubernetes/recreate_secret.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+head -4 secret.yaml | kubectl delete -f -
+cat secret.yaml|sed s#::SECRET::#$(cat limbo.env|base64 -w 0)#g |kubectl create -f -

--- a/kubernetes/secret.yaml
+++ b/kubernetes/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: limbo-secret-env-vars
+type: Opaque
+data:
+  limbo.env: ::SECRET::


### PR DESCRIPTION
I am aware that Shawn was working on a PR for docker support.  I also realize that this change might be hard to verify before merging, so if you're unsure, I wont be offended if you deny the merge.  I just wanted to share back some of the work I've done thus far.  

This is a PR of the code I have in PeterGrace/limbo which I use to create the automated docker registry image of [petergrace/limbo](https://hub.docker.com/r/petergrace/limbo/) -- with the public image, anyone can execute:
```docker run -ti -e SLACK_TOKEN=<their_token> petergrace/limbo```
and have a working limbo bot with the base plugins.  I use this same public image as the basis for my extended docker image that contains my internal, company-specific plugins.  I'm also making plugins for our in-house monitoring system, [bosun](http://bosun.org) and its associated functions, as well as a plugin for [desk.com](http://desk.com).  Those plugins I will submit PRs for when they're ready to be publicly released.

I am available to make additional documentation or answer questions as needed.