### PR TITLE
Handle message edit and delete

### DIFF
--- a/limbo/fakeserver.py
+++ b/limbo/fakeserver.py
@@ -27,12 +27,14 @@ class FakeSlack(object):
                 "name": botname,
             }
         }
-        self.username = "replbot"
+        self.username = "limbo_test"
+        self.userid = "1"
 
         self.users = users if users else {
             "1": User(self, "limbo_test", 1, "", 0),
             "2": User(self, "msguser", 2, "", 0),
             "3": User(self, "slackbot", 3, "", 0),
+            "4": User(self, "replbot", 4, "", 0),
         }
 
         self.bots = bots if bots else {

--- a/limbo/limbo.py
+++ b/limbo/limbo.py
@@ -57,7 +57,7 @@ def init_plugins(plugindir, plugins_to_load=None):
         import pkg_resources
         try:
             plugins = strip_extension(
-                    pkg_resources.resource_listdir(__name__, "plugins"))
+                pkg_resources.resource_listdir(__name__, "plugins"))
         except OSError:
             raise InvalidPluginDir(plugindir)
 
@@ -109,30 +109,30 @@ def run_hook(hooks, hook, *args):
 
     return responses
 
-def handle_bot_message(event, server):
+def get_user_id_from_message(msg, msgtype):
     try:
-        bot = server.slack.bots[event["bot_id"]]
+        if msgtype == "bot_message":
+            return msg["bot_id"]
+        if msgtype == "message_changed":
+            return msg["message"]["user"]
+        if msgtype == "message_deleted":
+            return msg["previous_message"]["user"]
+        if msgtype == "message":
+            return msg["user"]
     except KeyError:
-        logger.debug("bot_message event {0} has no bot".format(event))
-        return
-
-    return "\n".join(run_hook(server.hooks, "bot_message", event, server))
+            return None
 
 def handle_message(event, server):
-    subtype = event.get("subtype", "")
-    if subtype == "message_changed":
+    # plain mesages don't have a subtype; message_changed, bot_message,
+    # message_deleted et al do. use the subtype if available, otherwise
+    # just message
+    subtype = event.get("subtype", "message")
+    user = get_user_id_from_message(event, subtype)
+    if not user or user == server.slack.username or user == "slackbot":
+        logger.info("skipping message {} no user found or user is "
+            "self".format(event))
         return
-
-    if subtype == "bot_message":
-        return handle_bot_message(event, server)
-
-    try:
-        msguser = server.slack.users[event["user"]]
-    except KeyError:
-        logger.debug("event {0} has no user".format(event))
-        return
-
-    return "\n".join(run_hook(server.hooks, "message", event, server))
+    return "\n".join(run_hook(server.hooks, subtype, event, server))
 
 event_handlers = {
     "message": handle_message,
@@ -172,7 +172,7 @@ def loop(server, test_loop=None):
             events = server.slack.rtm_read()
             for event in events:
                 loops_without_activity = 0
-                logger.debug("got {0}".format(event.get("type", event)))
+                logger.debug("got {0}".format(event))
                 response = handle_event(event, server)
                 while response:
                     # The Slack API documentation says:
@@ -207,13 +207,14 @@ def loop(server, test_loop=None):
 
             end = time.time()
             runtime = start - end
-            time.sleep(max(1-runtime, 0))
+            time.sleep(max(1 - runtime, 0))
 
             if test_loop:
                 test_loop -= 1
     except KeyboardInterrupt:
         if os.environ.get("LIMBO_DEBUG"):
-            import ipdb; ipdb.set_trace()
+            import ipdb
+            ipdb.set_trace()
         raise
 
 def relevant_environ():

--- a/limbo/slack.py
+++ b/limbo/slack.py
@@ -58,6 +58,7 @@ class SlackClient(object):
     def __init__(self, token):
         self.token = token
         self.username = None
+        self.userid = None
         self.domain = None
         self.login_data = None
         self.websocket = None
@@ -124,6 +125,7 @@ class SlackClient(object):
         self.login_data = login_data
         self.domain = self.login_data["team"]["domain"]
         self.username = self.login_data["self"]["name"]
+        self.userid = self.login_data["self"]["id"]
         self.parse_channel_data(login_data["channels"])
         self.parse_channel_data(login_data["groups"])
         self.parse_channel_data(login_data["ims"])

--- a/test/plugins/echo.py
+++ b/test/plugins/echo.py
@@ -1,4 +1,11 @@
+def on_message_deleted(msg, server):
+    return "Deleted: {}".format(msg["previous_message"]["text"])
+
+def on_message_changed(msg, server):
+    text = msg.get("message", {"text": ""}).get("text", "")
+    if text.startswith("!echo"):
+        return "Changed: {}".format(text)
+
 def on_message(msg, server):
     if msg["text"].startswith("!echo"):
-        text = msg.get("text", "")
-        return text
+        return msg.get("text", "")

--- a/test/test_limbo.py
+++ b/test/test_limbo.py
@@ -123,7 +123,7 @@ def test_handle_message_slack_user_nil():
     slack = limbo.FakeSlack(users=users)
     server = limbo.FakeServer(slack=slack, hooks=hooks)
 
-    eq_(limbo.handle_message(event, server), "!echo Iñtërnâtiônàlizætiøn")
+    eq_(limbo.handle_message(event, server), u"!echo Iñtërnâtiônàlizætiøn")
 
 def test_handle_bot_message():
     msg = u"!echo Iñtërnâtiônàlizætiøn bot"


### PR DESCRIPTION
Previously, I had banned handling message editing because limbo's
messages are echoed back as message edits and it was an easy way to
ignore our own messages to prevent message loops.

* Handle message update and delete
    * use the `on_message_changed` and `on_message_deleted` functions to
      handle them, respectively
* test message update and delete
* add user id to slack server
    * may be useful in the future, easy to add
* return to manually checking for self messages and slackbot messages
    * do people want to handle slackbot messages in plugins?
* clean up handle_message

Fixes #78