### PR TITLE
Add a glossary plugin

### DIFF
--- a/limbo/plugins/glossary.py
+++ b/limbo/plugins/glossary.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+import json
+import os
+import re
+
+"""
+!glossary <term> returns the term definition OR "I don't know that term."
+!glossary add <term>: <definition> adds the definition to limbo's glossary
+"""
+
+GLOSSARY_FILE = os.environ.get('LIMBO_GLOSSARY_FILE', "/tmp/glossary.json")
+
+
+def define(term, definition):
+    with open(GLOSSARY_FILE, 'w+') as f:
+        try:
+            glossary = json.loads(f.read())
+        except ValueError:
+            glossary = {}
+
+        action = bool(glossary.get(term, False)) and "Updated" or "Added"
+        glossary[term] = definition
+        f.write(json.dumps(glossary))
+        return "%s a definition for %s"% (action, term)
+
+
+def remove(term):
+    with open(GLOSSARY_FILE, 'w+') as f:
+        try:
+            glossary = json.loads(f.read())
+        except ValueError:
+            return "There aren't any definitions to remove yet! Add a definition with '!glossary add <term>: <definition>'"
+
+        del(glossary[term])
+        f.write(json.dumps(glossary))
+        return "Removed definition for %s" % term
+
+
+def lookup(term):
+    not_found = "I don't know that term. Add a definition with '!glossary add <term>: <definition>'."
+
+    try:
+        with open(GLOSSARY_FILE, 'r') as f:
+            try:
+                glossary = json.loads(f.read())
+            except ValueError:
+                glossary = {}
+            definition = glossary.get(term, None)
+            if not definition:
+                return not_found
+            return definition
+    except IOError:
+        return not_found
+
+
+def on_message(msg, server):
+    text = msg.get("text", "")
+    match = re.match(r'!glossary (add\s+)?([^:]*)(.*)?', text)
+
+    if not match:
+        return
+
+    groups = match.groups()
+    if groups[0]:
+        term = groups[1]
+        definition = groups[2].lstrip(':').strip()
+        return define(term, definition)
+    else:
+        return lookup(groups[1])
+
+on_bot_message = on_message

--- a/limbo/plugins/glossary.py
+++ b/limbo/plugins/glossary.py
@@ -11,30 +11,34 @@ import re
 GLOSSARY_FILE = os.environ.get('LIMBO_GLOSSARY_FILE', "/tmp/glossary.json")
 
 
-def define(term, definition):
-    with open(GLOSSARY_FILE, 'w+') as f:
+def add(term, definition):
+    with open(GLOSSARY_FILE, 'r') as f:
         try:
             glossary = json.loads(f.read())
         except ValueError:
             glossary = {}
 
-        action = bool(glossary.get(term, False)) and "Updated" or "Added"
-        glossary[term] = definition
-        f.write(json.dumps(glossary))
-        return "%s a definition for %s"% (action, term)
+    action = bool(glossary.get(term, False)) and "Updated" or "Added"
+    glossary[term] = definition
 
+    with open(GLOSSARY_FILE, 'w') as f:
+        f.write(json.dumps(glossary))
+
+    return "%s a definition for %s"% (action, term)
 
 def remove(term):
-    with open(GLOSSARY_FILE, 'w+') as f:
+    with open(GLOSSARY_FILE, 'r') as f:
         try:
             glossary = json.loads(f.read())
         except ValueError:
             return "There aren't any definitions to remove yet! Add a definition with '!glossary add <term>: <definition>'"
 
-        del(glossary[term])
-        f.write(json.dumps(glossary))
-        return "Removed definition for %s" % term
+    del(glossary[term])
 
+    with open(GLOSSARY_FILE, 'w') as f:
+        f.write(json.dumps(glossary))
+
+    return "Removed definition for %s" % term
 
 def lookup(term):
     not_found = "I don't know that term. Add a definition with '!glossary add <term>: <definition>'."
@@ -55,17 +59,24 @@ def lookup(term):
 
 def on_message(msg, server):
     text = msg.get("text", "")
-    match = re.match(r'!glossary (add\s+)?([^:]*)(.*)?', text)
+    match = re.match(r'!gloss(ary)? (add|remove\s+)?([^:]*)(.*)?', text, re.IGNORECASE)
 
     if not match:
         return
 
+    if not os.path.isfile(GLOSSARY_FILE):
+        open(GLOSSARY_FILE, 'a').close()
+
     groups = match.groups()
-    if groups[0]:
-        term = groups[1]
-        definition = groups[2].lstrip(':').strip()
-        return define(term, definition)
+    if groups[1]:
+        action = groups[1].strip()
+        if action == 'add':
+            term = groups[2].strip()
+            definition = groups[3].lstrip(':').strip()
+            return add(term, definition)
+        elif action == 'remove':
+            return remove(groups[2])
     else:
-        return lookup(groups[1])
+        return lookup(groups[2])
 
 on_bot_message = on_message


### PR DESCRIPTION
Adds a glossary plugin to help with frequently used, seldom understood or confusing terms used by your team.

Try to look up a term:

```
> !glossary FYSA
I don't know that term. Add a definition with '!glossary add <term>: <definition>'.
```

Add a definition for a term:

```
> !glossary add FYSA: For Your Situational Awareness.
Added a definition for FYSA
```

And, once more:

```
> !glossary FYSA
For Your Situational Awareness.
```

To remove:

```
> !glossary remove FYSA
Removed definition for FYSA
```

Notes:
- Anyone can add or remove a term from the glossary.
- Can shorten the command to `!gloss` to save some key strokes.
- Use the env car `LIMBO_GLOSSARY_FILE` to set the location where limbo should store terms and definitions. Defaults to `/tmp/glossary.json`