### PR TITLE
add .cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ slask.egg-info/
 .start.sh
 .vagrant
 .python-version
+.cache


### PR DESCRIPTION
Running pytest creates a `.cache` dir in the root of the repo. Adding it to .gitignore.