### PR TITLE
Handle large user list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ except:
 
 setup(
     name='limbo',
-    version='6.0.0',
+    version='6.0.1',
     description='Simple and Clean Slack Chatbot',
     long_description=longdesc,
     author='Bill Mill',


### PR DESCRIPTION
With a very large team, the series of calls to load up the user list
can run up against slack's rate limiting. So:

* up the limit from 25 to 250
* log if we hit the rate limit and return the objs we loaded so far
  * it's better to have a partial members list and be running than to die (I think?)
* sleep for a second between calls. There should be no more than a few at 250 per call
* bump version to 6.0.1