### PR TITLE
add `make test-network` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ testall: requirements
 test: install
 	LANG=en_US.UTF-8 pytest --cov=limbo --cov-report term-missing test
 
+.PHONY: test-network
+test-network: install
+	LIMBO_NETWORK_TESTS=True make test
+
 .PHONY: clean
 clean:
 	rm -rf build dist limbo.egg-info

--- a/test/test_plugins/test_calc.py
+++ b/test/test_plugins/test_calc.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-import vcr
+from .utils import VCR
 
 DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
@@ -10,12 +10,12 @@ sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
 from calc import on_message
 
 def test_calc():
-    with vcr.use_cassette('test/fixtures/calc_basic.yaml'):
+    with VCR.use_cassette('test/fixtures/calc_basic.yaml'):
         ret = on_message({"text": u"!calc 2469*5"}, None)
         assert '12,345' in ret
 
 def test_unicode():
-    with vcr.use_cassette('test/fixtures/calc_unicode.yaml'):
+    with VCR.use_cassette('test/fixtures/calc_unicode.yaml'):
         # บาท is the Thai Bhat (spelled in Thai, obvs)
         ret = on_message({"text": u"!calc 10 dollars in บาท"}, None)
         # no exception == success

--- a/test/test_plugins/test_commit.py
+++ b/test/test_plugins/test_commit.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-import vcr
+from .utils import VCR
 
 DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
@@ -10,6 +10,6 @@ sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
 from commit import on_message
 
 def test_commit():
-  with vcr.use_cassette('test/fixtures/commit.yaml'):
-    ret = on_message({"text": u"!commit"}, None)
-    assert 'stuff' in ret
+    with VCR.use_cassette('test/fixtures/commit.yaml'):
+        ret = on_message({"text": u"!commit"}, None)
+        assert 'stuff' in ret

--- a/test/test_plugins/test_dog.py
+++ b/test/test_plugins/test_dog.py
@@ -2,14 +2,15 @@
 import os
 import sys
 
-import vcr
+from .utils import VCR
 
 DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
 
 from dog import on_message
 
+
 def test_dog():
-  with vcr.use_cassette('test/fixtures/dog.yaml'):
-    ret = on_message({"text": u"!dog"}, None)
-    assert "https://dog.ceo/api/img/" in ret
+    with VCR.use_cassette('test/fixtures/dog.yaml'):
+        ret = on_message({"text": u"!dog"}, None)
+        assert "https://dog.ceo/api/img/" in ret

--- a/test/test_plugins/test_flip.py
+++ b/test/test_plugins/test_flip.py
@@ -2,8 +2,6 @@
 import os
 import sys
 
-import vcr
-
 DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
 

--- a/test/test_plugins/test_gif.py
+++ b/test/test_plugins/test_gif.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-import vcr
+from .utils import VCR
 
 DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
@@ -13,11 +13,11 @@ from gif import on_message
 bananas_gifs = ['http://byt.wpengine.netdna-cdn.com/wp-content/uploads/2014/09/banana-dolphin-and-boy.gif', 'http://joedale.typepad.com/photos/uncategorized/2008/05/29/bananas.gif', 'http://orig04.deviantart.net/a8fc/f/2012/269/a/b/i_heart_banana_by_mnrart-d5fyx04.gif', 'http://images2.wikia.nocookie.net/illogicopedia/images/3/31/Dancing_Banana.gif', 'http://media.giphy.com/media/PlwtdKszlxyLK/giphy.gif', 'https://s-media-cache-ak0.pinimg.com/originals/81/36/86/813686513bb0ea580e9891fc15ec7678.jpg', 'http://www.webweaver.nu/clipart/img/misc/food/fruit/bunch-of-bananas.gif', 'http://www.animatedimages.org/data/media/330/animated-banana-image-0039.gif', 'http://www.rockinghamremembered.com/images/bananas.gif', 'http://ak-hdl.buzzfed.com/static/2015-09/11/13/imagebuzz/webdr07/anigif_optimized-6124-1441992418-1.gif', 'http://www.picgifs.com/graphics/b/bananas/graphics-bananas-761495.gif', 'http://volweb.utk.edu/SCHOOL/sweetwjh/dancing%20banana.gif', 'http://i.imgur.com/LQzD19d.gif', 'http://media.giphy.com/media/LldwJVCUlhRmg/giphy.gif', 'http://images5.fanpop.com/image/photos/30600000/Banana-gif-bananas-30667445-140-140.gif', 'http://www.sevenoaksart.co.uk/images/banana2.gif', 'http://ww2.valdosta.edu/~kabehland/gobananas.gif', 'http://www.comevisit.com/chuckali/bananas.gif', 'http://media.giphy.com/media/1MqvxsrhMHrGw/giphy.gif', 'https://strengthandsweets.files.wordpress.com/2014/01/bananadance.gif']
 
 def test_gif():
-    with vcr.use_cassette('test/fixtures/gif_bananas.yaml'):
+    with VCR.use_cassette('test/fixtures/gif_bananas.yaml'):
         ret = on_message({"text": u"!gif bananas"}, None)
         assert ret in bananas_gifs, "{0} not in {1}".format(ret, bananas_gifs)
 
 def test_unicode():
-    with vcr.use_cassette('test/fixtures/gif_unicode.yaml'):
+    with VCR.use_cassette('test/fixtures/gif_unicode.yaml'):
         ret = on_message({"text": u"!gif Mötörhead"}, None)
         # not blowing up == success, for our purposes

--- a/test/test_plugins/test_github.py
+++ b/test/test_plugins/test_github.py
@@ -4,7 +4,7 @@ import os
 import sys
 import sqlite3
 
-import vcr
+from .utils import VCR
 
 DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
@@ -19,7 +19,7 @@ def dicteq(a, b):
     assert sorted(a.items()) == sorted(b.items())
 
 def test_basic():
-    with vcr.use_cassette('test/fixtures/github_issues.yaml'):
+    with VCR.use_cassette('test/fixtures/github_issues.yaml'):
         ret = on_message({"text": u"!hub issue 5 -r llimllib/limbo", "channel": "test_channel"}, SERVER)
         #import ipdb; ipdb.set_trace()
         expected = {

--- a/test/test_plugins/test_image.py
+++ b/test/test_plugins/test_image.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-import vcr
+from .utils import VCR
 
 DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
@@ -13,11 +13,11 @@ from image import on_message, unescape
 bananas_images = ['http://cdn1.medicalnewstoday.com/content/images/articles/271157-bananas.jpg', 'http://runhaven.com/wp-content/uploads/minion-bananas.jpg', 'https://www.organicfacts.net/wp-content/uploads/2013/05/Banana21.jpg', 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Bananas.jpg/1024px-Bananas.jpg', 'http://dreamatico.com/data_images/banana/banana-3.jpg', 'http://www.esbtrib.com/wp-content/uploads/2015/09/bananas1.jpeg', 'http://weknowyourdreams.com/images/banana/banana-07.jpg', 'http://saltmarshrunning.com/wp-content/uploads/2014/09/bananasf.jpg', 'https://www.organicfacts.net/wp-content/uploads/2013/05/Banana3.jpg', 'http://bed56888308e93972c04-0dfc23b7b97881dee012a129d9518bae.r34.cf1.rackcdn.com/sites/default/files/imagecache/310_square/bananas_1.jpg', 'http://www.fitnessworksmb.com/wp-content/uploads/banana.jpg', 'https://media.licdn.com/mpr/mpr/shrinknp_800_800/AAEAAQAAAAAAAARXAAAAJGU2NGE1NzUzLTgxNzYtNDZiZC05YWY1LWQ4ZWE0OTk0NDY2Mw.jpg', 'https://charinacabswords.files.wordpress.com/2015/07/health-benefits-of-bananas.jpg', 'http://www.unitedfreshservices.com/content/01-services_bananen_rijperij/banana_ripening.jpg', 'http://parentinghealthybabies.com/wp-content/uploads/2013/03/bananas.jpg', 'http://foodmatters.tv/images/bananas.jpg', 'http://a3145z3.americdn.com/wp-content/uploads/2014/03/10-amazing-facts-bananas.jpg', 'http://www.popsci.com/sites/popsci.com/files/styles/large_1x_/public/import/2014/bananas-flickr-ian-ransley-design-dog-ccby20.jpg?itok\\0754G6KHch5', 'http://nobacks.com/wp-content/uploads/2014/11/Banana-21.png', 'http://i.telegraph.co.uk/multimedia/archive/01423/banana_1423728c.jpg']
 
 def test_image():
-    with vcr.use_cassette('test/fixtures/image_bananas.yaml'):
+    with VCR.use_cassette('test/fixtures/image_bananas.yaml'):
         ret = on_message({"text": u"!image bananas"}, None)
         assert ret in bananas_images, "{0} not in {1}".format(ret, bananas_images)
 
 def test_unicode():
-    with vcr.use_cassette('test/fixtures/image_unicode.yaml'):
+    with VCR.use_cassette('test/fixtures/image_unicode.yaml'):
         ret = on_message({"text": u"!image Mötörhead"}, None)
         # not blowing up == success, for our purposes

--- a/test/test_plugins/test_stock.py
+++ b/test/test_plugins/test_stock.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-import vcr
+from .utils import VCR
 
 DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
@@ -10,7 +10,7 @@ sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
 from stock import on_message, stockprice
 
 def test_apple():
-    with vcr.use_cassette('test/fixtures/stock_apple.yaml'):
+    with VCR.use_cassette('test/fixtures/stock_apple.yaml'):
         ret = on_message({"text": u"$aapl"}, None)
         assert ':chart_with_upwards_trend:' in ret
         assert 'Apple Inc.' in ret
@@ -18,21 +18,21 @@ def test_apple():
         assert '+1.62' in ret
 
 def test_nonexistent():
-    with vcr.use_cassette('test/fixtures/stock_none'):
+    with VCR.use_cassette('test/fixtures/stock_none'):
         ret = on_message({"text": u"bana"}, None)
         assert ret == None
 
 def test_unicode():
-    with vcr.use_cassette('test/fixtures/stock_unicode.yaml'):
+    with VCR.use_cassette('test/fixtures/stock_unicode.yaml'):
         ret = on_message({"text": u"$äapl"}, None)
         assert ret == None
 
 def test_multiple():
-    with vcr.use_cassette('test/fixtures/stock_multiple.yaml'):
+    with VCR.use_cassette('test/fixtures/stock_multiple.yaml'):
         ret = on_message({"text": u"$goog $aapl"}, None)
         assert 'Google Inc' in ret
 
 def test_price():
-    with vcr.use_cassette('test/fixtures/stock_none'):
+    with VCR.use_cassette('test/fixtures/stock_none'):
         ret = on_message({"text": u"the price is $12.43"}, None)
         assert ret == None

--- a/test/test_plugins/test_stockphoto.py
+++ b/test/test_plugins/test_stockphoto.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-import vcr
+from .utils import VCR
 
 DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
@@ -10,12 +10,12 @@ sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
 from stockphoto import on_message
 
 def test_basic():
-    with vcr.use_cassette('test/fixtures/stockphoto_basic.yaml'):
+    with VCR.use_cassette('test/fixtures/stockphoto_basic.yaml'):
         ret = on_message({"text": u"!stock woman eating salad"}, None)
         assert ret in women_eating_salad
 
 def test_unicode():
-    with vcr.use_cassette('test/fixtures/stockphoto_unicode.yaml'):
+    with VCR.use_cassette('test/fixtures/stockphoto_unicode.yaml'):
         ret = on_message({"text": u"!stock übermensch"}, None)
         # not blowing up == success
 

--- a/test/test_plugins/test_weather.py
+++ b/test/test_plugins/test_weather.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-import vcr
+from .utils import VCR
 
 DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
@@ -12,11 +12,11 @@ from weather import on_message
 os.environ["WEATHER_API_KEY"] = "abcdef"
 
 def test_basic():
-    with vcr.use_cassette('test/fixtures/weather_basic.yaml'):
+    with VCR.use_cassette('test/fixtures/weather_basic.yaml'):
         ret = on_message({"text": u"!weather Oahu, HI"}, None)
         assert ":cloud: Sat 71" in ret
 
 def test_unicode():
-    with vcr.use_cassette('test/fixtures/weather_unicode.yaml'):
+    with VCR.use_cassette('test/fixtures/weather_unicode.yaml'):
         ret = on_message({"text": u"!weather Provençal"}, None)
         # not blowing up == success

--- a/test/test_plugins/test_wiki.py
+++ b/test/test_plugins/test_wiki.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-import vcr
+from .utils import VCR
 
 DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
@@ -10,12 +10,12 @@ sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
 from wiki import on_message
 
 def test_basic():
-    with vcr.use_cassette('test/fixtures/wiki_basic.yaml'):
+    with VCR.use_cassette('test/fixtures/wiki_basic.yaml'):
         ret = on_message({"text": u"!wiki dog"}, None)
         assert "member of the canidae family" in ret
         assert "http://en.wikipedia.org/wiki/Dog" in ret
 
 def test_unicode():
-    with vcr.use_cassette('test/fixtures/wiki_unicode.yaml'):
+    with VCR.use_cassette('test/fixtures/wiki_unicode.yaml'):
         ret = on_message({"text": u"!wiki नेपाल"}, None)
         # not blowing up == success

--- a/test/test_plugins/test_youtube.py
+++ b/test/test_plugins/test_youtube.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-import vcr
+from .utils import VCR
 
 DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
@@ -10,11 +10,11 @@ sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
 from youtube import on_message
 
 def test_basic():
-    with vcr.use_cassette('test/fixtures/youtube_basic.yaml'):
+    with VCR.use_cassette('test/fixtures/youtube_basic.yaml'):
         ret = on_message({"text": u"!youtube live long and prosper"}, None)
         assert ret == "https://www.youtube.com/watch?v=DyiWkWcR86I"
 
 def test_unicode():
-    with vcr.use_cassette('test/fixtures/youtube_unicode.yaml'):
+    with VCR.use_cassette('test/fixtures/youtube_unicode.yaml'):
         ret = on_message({"text": u"!youtube 崖の上のポニョ"}, None)
         # not blowing up == success

--- a/test/test_plugins/utils.py
+++ b/test/test_plugins/utils.py
@@ -1,0 +1,22 @@
+import os
+
+import vcr
+
+# use environment variable to enable network tests
+LIMBO_NETWORK_TESTS = os.environ.get('LIMBO_NETWORK_TESTS', False)
+print(os.environ)
+
+
+def before_record_callback(request):
+    """
+    Run tests using network API calls if LIMBO_NETWORK_TESTS; otherwise use vcr fixtures
+    """
+    if LIMBO_NETWORK_TESTS:
+        return None
+    else:
+        return request
+
+
+VCR = vcr.VCR(
+    before_record=before_record_callback
+)


### PR DESCRIPTION
Normally, when tests are run we use vcr fixtures for any external API
requests that our test calls make. This is great! It lets us run our
tests quickly and deterministically, without worrying about the slowness
or availablity of external services.

However, this means our tests can't alert us to external APIs changing.
If an API changes, our vcr fixtures would continue to provide us with
old API data, giving us false-positives that our plugins were working.

`make test-network` lets us run the same tests but ignores the vcr
fixtures. This means that tests will hit the external network. It uses
an environment variable, set by the Makefile, to alert our test utils
whether or not to use vcr for a given run.

Closes #123