### PR TITLE
Add config loader from config file

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,7 @@
+[DEFAULT]
+
+SLACK_TOKEN = token
+
+[BOT]
+
+logfile = logfile.log

--- a/limbo/limbo.py
+++ b/limbo/limbo.py
@@ -15,6 +15,7 @@ import traceback
 from .slack import SlackClient, SlackConnectionError, SlackLoginError
 from .server import LimboServer
 from .fakeserver import FakeServer
+from .config import Config
 
 CURDIR = os.path.abspath(os.path.dirname(__file__))
 DIR = functools.partial(os.path.join, CURDIR)
@@ -151,19 +152,6 @@ def handle_event(event, server):
     if handler:
         return handler(event, server)
 
-def getif(config, name, envvar):
-    if envvar in os.environ:
-        config[name] = os.environ.get(envvar)
-
-def init_config():
-    config = {}
-    getif(config, "token", "SLACK_TOKEN")
-    getif(config, "loglevel", "LIMBO_LOGLEVEL")
-    getif(config, "logfile", "LIMBO_LOGFILE")
-    getif(config, "logformat", "LIMBO_LOGFORMAT")
-    getif(config, "plugins", "LIMBO_PLUGINS")
-
-    return config
 
 def loop(server, test_loop=None):
     """Run the main loop
@@ -282,7 +270,7 @@ def encode(str_, codec='utf8'):
         return str_.encode(codec)
 
 def main(args):
-    config = init_config()
+    config = Config()
     if args.test:
         init_log(config)
         return repl(FakeServer(), args)

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ virtualenv==15.1.0
 webencodings==0.5.1
 websocket-client==0.44.0
 wrapt==1.10.10
+configparser==3.5.0

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,27 @@
+# -*- coding: UTF-8 -*-
+import os
+
+DIR = os.path.dirname(os.path.realpath(__file__))
+PARENT = os.path.split(DIR)[0]
+
+from limbo.config import Config
+
+
+def test_config():
+    # test wrong config location
+    os.environ["LIMBO_CONFIG_LOCATION"] = "config.ini"
+    try:
+        config = Config()
+        assert False
+    except IOError:
+        assert True
+
+    # know a correct config location
+    os.environ["LIMBO_CONFIG_LOCATION"] = "../config.ini"
+    config = Config()
+    assert config["SLACK_TOKEN"] == "token"
+
+    # test non existing setting
+    result = config.get("weather", "weather_token")
+    assert not result
+


### PR DESCRIPTION
With this config we load configuration variables from a config file and from the environment.
If a variable is present in both (config and env) the env variable is used.
This makes easy to quick change a particular variable between restarts (the debug level e.g.).