### PR TITLE
Add --botname feature to fetch user-name associated with SLACK_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ I recommend that you always run limbo in a [virtualenv](http://docs.python-guide
 * -c: Run a single command.
 * --database, -d: Where to store the limbo sqlite3 database. Defaults to limbo.sqlite3.
 * --pluginpath, -pp: The path where limbo should look to find its plugins (defaults to /plugins).
+* --botname: Prints the user-name associated with SLACK_TOKEN (as reported by Slack `auth.test` endpoint).
 
 ## Environment Variables
 

--- a/bin/limbo
+++ b/bin/limbo
@@ -12,6 +12,8 @@ parser.add_argument('--database', '-d', dest='database_name', default='limbo.sql
                     help="Where to store the limbo sqlite database. Defaults to limbo.sqlite3")
 parser.add_argument('--pluginpath', '-pp', dest='pluginpath', default=None,
                     help="The path where limbo should look to find its plugins")
+parser.add_argument('--botname', dest='botname', action='store_true',
+                    help='Print name of Slackbot to stdout')
 args = parser.parse_args()
 
 main(args)

--- a/limbo/limbo.py
+++ b/limbo/limbo.py
@@ -324,11 +324,11 @@ def main(args):
     server = init_server(args, config)
 
     try:
+        server.slack.rtm_connect()
         if args.botname:
-            print(server.slack.botname())
+            print(server.slack.username)
             return
 
-        server.slack.rtm_connect()
         # run init hook. This hook doesn't send messages to the server (ought it?)
         run_hook(server.hooks, "init", server)
 

--- a/limbo/limbo.py
+++ b/limbo/limbo.py
@@ -324,6 +324,10 @@ def main(args):
     server = init_server(args, config)
 
     try:
+        if args.botname:
+            print(server.slack.botname())
+            return
+
         server.slack.rtm_connect()
         # run init hook. This hook doesn't send messages to the server (ought it?)
         run_hook(server.hooks, "init", server)

--- a/limbo/slack.py
+++ b/limbo/slack.py
@@ -147,15 +147,6 @@ class SlackClient(object):
                 user = data["user"]
                 self.parse_users([user])
 
-    def botname(self):
-        reply = self.do("auth.test")
-        if reply.status_code != 200:
-            raise SlackConnectionError
-        r = reply.json()
-        if not r["ok"]:
-            raise SlackLoginError
-        return r["user"]
-
     def rtm_connect(self):
         reply = self.do("rtm.connect")
         if reply.status_code != 200:

--- a/limbo/slack.py
+++ b/limbo/slack.py
@@ -147,6 +147,15 @@ class SlackClient(object):
                 user = data["user"]
                 self.parse_users([user])
 
+    def botname(self):
+        reply = self.do("auth.test")
+        if reply.status_code != 200:
+            raise SlackConnectionError
+        r = reply.json()
+        if not r["ok"]:
+            raise SlackLoginError
+        return r["user"]
+
     def rtm_connect(self):
         reply = self.do("rtm.connect")
         if reply.status_code != 200:


### PR DESCRIPTION
When writing deployment scripts and other automation, it is useful to have a Limbo bot's user name as it appears in Slack.  For example, in our AWS deployment scripts, we use this botname as the "service name" in Amazon's Elastic Container Service.  The Slack API has an API endpoint (`auth.test`) that returns this user name (among other information).  This pull request adds a flag to Limbo that calls this endpoint and then prints the resulting name (and then exits -- when `--botname` is used, Limbo does not enter its event loop).