### PR TITLE
Update use of Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+**/*.pyc
+**/*~
+**/*.config.py
+
+.git
+.tox
+NOTES
+build
+dist
+docs
+limbo.egg-info
+limbo.sqlite3
+slask.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,13 @@ notifications:
 
 jobs:
   include:
-    - stage: Docker Test
+    - stage: test
       sudo: required
       services:
         - docker
+      env:
+        # Provides a useful label in TravisCI Web UI
+        - DONE_IN_DOCKER=true
       install:
         - sudo apt-get update
         - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,16 @@ notifications:
   slack:
     secure: qTTpPJZRjkFNlWUQd4M4odA+/QnuEqoD3ole8tQA+oFo2hzA7toQbAorgKd20mJ0VMLbrTxUDeCHwuLH6EYs0k9gnaDx7J8gaohW3ePHU6vncGfSh/9r8jCLHOdD/23ySm6D4TKR5SV7izNS+4WyqLqeLugdk5rFCwW4JJS118U=
   email: false
+
+jobs:
+  include:
+    - stage: Docker Test
+      sudo: required
+      services:
+        - docker
+      install:
+        - sudo apt-get update
+        - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+      script:
+        - docker-compose build
+        - docker-compose run test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,47 @@
-FROM 1science/alpine
+FROM ubuntu
 
-ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# Follow APT advice from
+#    https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/
+RUN set -ex; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install apt-utils; \
+    DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+      apt-transport-https \
+      ca-certificates \
+      curl \
+      gcc \
+      gnupg2 \
+      libffi-dev \
+      libssl-dev \
+      locales \
+      lsb-release \
+      python3 \
+      python3-dev \
+      python3-pip \
+      software-properties-common \
+    ; \
+    locale-gen en_US.UTF-8; \
+    ln -s /usr/bin/python3 /usr/bin/python; \
+    ln -s /usr/bin/pip3 /usr/bin/pip; \
+    pip install --upgrade pip setuptools; \
+    :
 
-# get our basic-needs sorted
-RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
-RUN apk update
-RUN apk-install python3 python3-dev vim bash    \
-                curl      \
-    && curl "https://bootstrap.pypa.io/get-pip.py" | python3 \
-    && pip install --upgrade pip setuptools     \
-    && ln -s /usr/bin/python3 /usr/bin/python   \
-    && mkdir -p /opt /app
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
-ADD . /app
+ADD requirements.txt /app/
 WORKDIR /app
-RUN pip install -e .
-CMD /app/bin/kube-limbo
+RUN pip install -r requirements.txt
 
-# vim: set expandtab tabstop=4 shiftwidth=4 autoindent smartindent:
+ADD bin/limbo /app/bin/limbo
+ADD limbo /app/limbo/
+ADD setup.py /app/
+RUN set -ex; \
+    python setup.py install; \
+    rm -rf build dist limbo.egg-info; \
+    :
+
+ADD test /app/test/
+
+ENTRYPOINT ["/usr/local/bin/limbo"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,0 @@
-FROM petergrace/limbo
-# Add your plugins with lines similar to these
-ADD limbo/plugins/my_new_plugin.py /app/limbo/plugins/
-ADD limbo/plugins/my_other_new_plugin.py /app/limbo/plugins/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-NAMESPACE=llimllib
-APP=limbo
 
 .PHONY: testall
 testall: requirements
@@ -41,18 +39,3 @@ publish:
 .PHONY: flake8
 flake8:
 	flake8 limbo test
-
-NAMESPACE=petergrace
-APP=limbo
-
-.PHONY: docker_build
-docker_build:
-	docker build -f Dockerfile.dev -t ${NAMESPACE}/${APP} .
-
-.PHONY: docker_run
-docker_run:
-	docker run -d -e SLACK_TOKEN=${SLACK_TOKEN} ${NAMESPACE}/${APP}
-
-.PHONY: docker_stop
-docker_clean:
-	docker stop $(docker ps -a -q  --filter ancestor=petergrace/limbo --format="{{.ID}}")

--- a/README.md
+++ b/README.md
@@ -60,13 +60,54 @@ These are the current default plugins:
 
 ## Docker
 
-  * How do I try out Limbo via docker?
-    - @PeterGrace maintains a public build of limbo, available from the docker registry.  Executing `make docker_run` will start the default bot.
-    - `make docker_stop` will stop the bot
-  * When I start the docker container, I see an error about unable to source limbo.env.  Is this a problem?
-    - No.  The limbo.env file only exists when using Kubernetes with the included opaque secret recipe for storing your environment variables.
-  * I'd like to develop plugins for Limbo, but would still like to use Docker to run the bot.  Is there a quick way to add plugins to the bot?
-    - Yes!  Use the included Dockerfile.dev as a template, and simply build via `make docker_build`  You'll then need to start the bot with your new_image_name, for example `docker run -d -e SLACK_TOKEN=<your_token> new_image_name`
+Docker can be used as an alternative tool for building, testing, and running Limbo.  With this alternative, you only need to install Docker on your dev machine: commands for downloading Limbo's dependencies, building and testing Limbo itself, and, ultimately, running Limbo can be run inside Docker containers.
+
+To build Limbo using Docker, simply type:
+
+```
+docker-compose build
+```
+
+(This build command -- and all the Docker commands in this section -- must be issued from the root of the Limbo source directory.)  This build command creates an image tagged as simply `limbo` in your local cache maintained by `dockerd`.  The first time you run this command, it will take quite a few minutes because Docker has to download a lot of dependencies.  Subsequent runs will be quite fast because Docker will have cached these dependencies locally.
+
+After you've built the Limbo image, you can test Limbo using Docker by typing:
+
+```
+docker-compose run test
+```
+
+This command creates a container using the `limbo` image, binds the container's terminal to the terminal of the shell you used to run this command, and then runs the Limbo test suit, sending its output to your terminal.
+
+Assuming the test completes successfull, you can run Limbo in a Docker container by typing:
+
+```
+docker-compose run limbo
+```
+
+Be sure to set your `SLACK_TOKEN` environment variable before running Slack.  As before, this command will create a container bound to your current terminal and start the Limbo program.  You can type control-C to break out of Limbo.
+
+If for some reason Limbo is detatched from your terminal, you can kill it with the following command:
+
+```
+docker stop `docker ps -q --filter ancestor=limbo --format="{{.ID}}"`
+```
+
+You can pass command-line arguments to `limbo` by adding them to the command line above.  For example:
+
+```
+docker-compose run limbo --help
+```
+
+will print the Limbo help message.
+
+The Docker Compose configuration we've provided will automatically pass `SLACK_TOKEN` plus the various `LIMBO_*` environment variables from your shell into the environment of the container used to run Limbo.  If you want to override those variables -- or set a variable not on this list -- you can use the `-e` option, for example:
+
+```
+docker-compose run -e LIMBO_LOGLEVEL=DEBUG limbo
+```
+
+**Warning to Windows users.**  Docker does no line-ending conversion when creating the build context or copying files from the context into Docker images.  Thus, if you checked-out Limbo with `autocrlf=true` -- and thus converted Unix line-endings into DOS line-endings -- the Docker image created for Limbo can break.  Thus, it's best to checkout Limbo on Windows using `autocrlf=input` (indeed, the Interwebs seem to suggest this is the best setting for all Git work on Windows).  Just be sure your editor doesn't start introducing DOS line-endings when you edit files (be especially careful for new files).
+
 
 ## Contributors
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,7 @@
+version: "2"
+
+services:
+  # "docker-compose run" entry for invoking our tests
+  test:
+    image: limbo
+    entrypoint: [ "pytest", "--cov=limbo", "--cov-report", "term-missing", "test" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "2"
+
+services:
+  # Laptop overrides for limbo service
+  limbo:
+    image: limbo
+    build: .
+    environment:
+      SLACK_TOKEN:
+      LIMBO_LOGLEVEL:
+      LIMBO_LOGFILE:
+      LIMBO_LOGFORMAT:
+      LIMBO_PLUGINS:


### PR DESCRIPTION
Limbo's use of Docker has become a bit stale.  This pull request contains a refresh.

The goal of the use of Docker in this PR is two-fold:

1. Minimize the dev environment required for Limbo.  In particular, developers only need Git and Docker on their laptop: with this patch, everything needed to build, test, and run Limbo is done inside Docker containers.  This minimized dev environment is great for teaching environments, where misconfigured laptops don't waste the time of students, professors or TAs.  Also, developers new to Limbo might start by using the Dockerized build and testing, avoiding problems associated with setting up a dev environment until they've become somewhat proficient at Limbo development.

2. Produce a Limbo Docker image that can be used for cloud deployments of Limbo (whether on Amazon, Google, Microsoft, or some private cloud).

This PR uses Docker Compose to drive Docker.  Compose is a layer on top of Docker that moves what used to be a crazy number of command-line arguments to `docker` into Docker Compose configuration files.  Docker Compose files have become a _de facto_ standard input to container orchestration systems, as they are accepted by Kubernetes, Elastic Container Service, and Mesos, as well as by Docker Swarm.

This PR includes changes to `.travis.yml` for testing of the new Docker code.  In particular, we use Travis [build stages](https://docs.travis-ci.com/user/build-stages/) to run the Dockerized build-and-test if (and only if) the full Limbo "test matrix" successfully passes.