### PR TITLE
handle user in message_replied

### DIFF
--- a/limbo/limbo.py
+++ b/limbo/limbo.py
@@ -129,7 +129,7 @@ def get_user_id_from_message(msg, msgtype):
     try:
         if msgtype == "bot_message":
             return msg["bot_id"]
-        if msgtype == "message_changed":
+        if msgtype in ["message_changed", "message_replied"]:
             return msg["message"]["user"]
         if msgtype == "message_deleted":
             return msg["previous_message"]["user"]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ except:
 
 setup(
     name="limbo",
-    version="8.0.2",
+    version="8.1.0",
     description="Simple and Clean Slack Chatbot",
     long_description=longdesc,
     author="Bill Mill",


### PR DESCRIPTION
on messages in threads, limbo was not properly handling the user id. Here's what a reply in a thread looks like:

```
{'type': 'message',
'subtype': 'message_replied',
'hidden': True,
'message': {
    'client_msg_id': 'f0cb2424-625f-4657-a067-850ddef48d4e',
    'type': 'message',
    'text': '!flip 1,2,3',
    'user': 'UABC12345',
    'ts': '1591025216.001900',
    'team': 'TABC12345',
    'thread_ts': '1591025216.001900',
    'parent_user_id': 'UABC12345',
    'reply_count': 0,
    'reply_users_count': 0,
    'latest_reply': '0000000000.000000',
    'reply_users': []},
'channel': 'CABC12345',
'event_ts': '1591025219.002200',
'ts': '1591025219.002200'}
```